### PR TITLE
docs + CI/release workflows + move to node-gis org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build (ESM + CJS)
+        run: bun run build
+
+      - name: Test
+        run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+# Publishes to npm when a version tag (e.g. v1.0.0, v1.0.0-beta.3) is pushed.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # setup-node provides the npm CLI + auth needed for `npm publish`.
+      - name: Setup Node (npm registry auth)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build (ESM + CJS)
+        run: bun run build
+
+      - name: Test
+        run: bun test
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (=$TAG_VERSION) does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Publishing version $PKG_VERSION"
+
+      - name: Publish to npm
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          # Prerelease versions (contain a hyphen) go to the "next" dist-tag,
+          # so a beta never overwrites "latest" for stable users.
+          if printf '%s' "$VERSION" | grep -q '-'; then
+            DIST_TAG=next
+          else
+            DIST_TAG=latest
+          fi
+          echo "Publishing with dist-tag: $DIST_TAG"
+          npm publish --access public --tag "$DIST_TAG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,57 +1,103 @@
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FJeongyong-park%2Fcsv-geojson-conv.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FJeongyong-park%2Fcsv-geojson-conv?ref=badge_shield)
+# csv-geojson-conv
 
-## csv-geojson-conv
+[![CI](https://github.com/node-gis/csv-geojson-conv/actions/workflows/ci.yml/badge.svg)](https://github.com/node-gis/csv-geojson-conv/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/csv-geojson-conv.svg)](https://www.npmjs.com/package/csv-geojson-conv)
+[![npm downloads](https://img.shields.io/npm/dm/csv-geojson-conv.svg)](https://www.npmjs.com/package/csv-geojson-conv)
+[![license](https://img.shields.io/npm/l/csv-geojson-conv.svg)](https://github.com/node-gis/csv-geojson-conv/blob/main/LICENSE)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv?ref=badge_shield)
 
-csv-geojson-conv is module for very easy to use for convert from CSV to GeoJSON.
+A tiny ESM/CJS module that converts a CSV string into a GeoJSON `FeatureCollection` of `Point` features. Works in Node.js and the browser. Ships with TypeScript types.
 
-no more spend your time 
+## Install
 
-## install
-
-``` sh
-# via npm
+```sh
 npm install csv-geojson-conv
-
-# via yarn
+# or
 yarn add csv-geojson-conv
+# or
+bun add csv-geojson-conv
 ```
 
-## HOW TO USE
+## Usage
 
-### via browser fetch method
+```js
+// ESM
+import csvToGeojson from 'csv-geojson-conv';
+// CommonJS
+const csvToGeojson = require('csv-geojson-conv');
+
+const csv = `Latitude,Longitude,Region,Name,Note
+37.4355672,126.9388092,서울,서울본부,
+35.0819546,129.0552017,부산,KBS중계소,`;
+
+const geojson = csvToGeojson(csv);
+```
+
+Result:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [126.9388092, 37.4355672] },
+      "properties": { "Latitude": "37.4355672", "Longitude": "126.9388092", "Region": "서울", "Name": "서울본부", "Note": "" }
+    }
+  ]
+}
+```
+
+### Browser (fetch)
 
 ```js
 import csvToGeojson from 'csv-geojson-conv';
-//or
-const csvToGeojson = require('csv-geojson-conv');
 
-fetch('data/repeater.csv').then(async res => {
-    const csvdata = await res.text();
-    if (csvdata) {
-        const geojson = csvToGeojson(csvdata) 
-    }
+fetch('data/points.csv')
+  .then((res) => res.text())
+  .then((csv) => {
+    const geojson = csvToGeojson(csv);
+    // ... render on a map
+  });
+```
+
+### Custom coordinate columns
+
+Default columns are `Latitude` and `Longitude`. Override them when your CSV differs:
+
+```js
+const geojson = csvToGeojson(csv, {
+  latitudeColumnName: 'lat',
+  longitudeColumnName: 'lon',
 });
 ```
 
-this is sample csv file.
-```csv
-Latitude,Longitude,Region,Name,Note
-37.4355672,126.9388092,서울,서울본부,
-35.0819546,129.0552017,부산,KBS중계소,
+## API
+
+```ts
+function csvToGeojson(
+  csv: string,
+  options?: {
+    latitudeColumnName?: string;  // default: "Latitude"
+    longitudeColumnName?: string; // default: "Longitude"
+  }
+): FeatureCollection<Point, Record<string, string>>;
 ```
 
-`Latitude` and `Longitude` columns become the GeoJSON `Point` coordinates; every other column is copied into the feature's `properties`. Coordinates must be valid WGS84 (latitude -90..90, longitude -180..180) or conversion throws.
+- The latitude/longitude columns become each feature's `Point` coordinates (GeoJSON order: `[longitude, latitude]`).
+- Every other column is copied verbatim into the feature's `properties` (values stay strings).
+- Empty lines are skipped; whitespace around values is trimmed.
 
-### if column names are different like that in your CSV.
+### Errors
 
-you can use with this options
+Conversion throws an `Error` (with the offending CSV row number) when:
 
-```js
-const geojson = csvToGeojson(csvdata, { latitudeColumnName: 'lat', longitudeColumnName: 'lon' })
-```
+- a coordinate column is missing,
+- a coordinate value is not a finite number, or
+- a coordinate is outside the valid WGS84 range (latitude `-90..90`, longitude `-180..180`).
 
 ## LICENSE
 
-Licensed [MIT](https://github.com/Jeongyong-park/csv-geojson-conv/blob/main/LICENSE)
+Licensed [MIT](https://github.com/node-gis/csv-geojson-conv/blob/main/LICENSE)
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FJeongyong-park%2Fcsv-geojson-conv.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FJeongyong-park%2Fcsv-geojson-conv?ref=badge_large)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv?ref=badge_large)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "email": "kladess@gmail.com",
     "url": "https://github.com/Jeongyong-park"
   },
-  "homepage": "https://github.com/Jeongyong-park/csv-geojson-conv",
+  "homepage": "https://github.com/node-gis/csv-geojson-conv#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/node-gis/csv-geojson-conv.git"
+  },
+  "bugs": {
+    "url": "https://github.com/node-gis/csv-geojson-conv/issues"
+  },
   "keywords": [
     "csv",
     "geojson",


### PR DESCRIPTION
## Summary
- **README rewrite:** npm + CI badges, accurate API signature, return shape, error semantics, ESM/CJS + browser examples.
- **CI workflow** (`ci.yml`): runs `bun install --frozen-lockfile` → build (ESM+CJS) → test on push/PR to `main`.
- **Release workflow** (`release.yml`): on `v*` tag, builds + tests, verifies tag matches `package.json` version, publishes to npm. Prerelease versions (with `-`) go to the `next` dist-tag so a beta never overwrites `latest`.
- **Org move:** `homepage` repointed to `node-gis`; added `repository` and `bugs` fields; README links + FOSSA badges updated.

## Required before release works
- Add repo secret `NPM_TOKEN` (npm automation token): Settings → Secrets and variables → Actions.
- FOSSA re-scan under the `node-gis` path for badges to resolve.

## Notes
- `author.url` left as the personal profile (author = person, not org).
- Version drift: local `1.0.0-beta.2` vs npm latest `1.0.0-beta.3` — bump before the next publish.

## Test
- `bun run build` clean
- `bun test` 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)