### PR TITLE
chore: release v1.0.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csv-geojson-conv",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.4",
   "description": "ESM/CJS module to convert CSV string to GeoJSON in node.js or browser",
   "packageManager": "bun@1.3.9",
   "author": {


### PR DESCRIPTION
## Summary
Bump `package.json` version `1.0.0-beta.2` → `1.0.0-beta.4`.

`1.0.0-beta.3` is already published on npm, so the next publishable version is `beta.4`.

## Release steps (after merge)
1. Ensure repo secret `NPM_TOKEN` exists.
2. Tag and push:
   ```sh
   git checkout main && git pull
   git tag v1.0.0-beta.4
   git push origin v1.0.0-beta.4
   ```
3. The Release workflow builds, tests, verifies the tag matches `package.json`, and publishes to npm under the `next` dist-tag (prerelease).

## Test
- `bun run build` clean
- `bun test` 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)