### PR TITLE
chore: scope package as @node-gis/csv-geojson-conv (v1.0.0-beta.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# csv-geojson-conv
+# @node-gis/csv-geojson-conv
 
 [![CI](https://github.com/node-gis/csv-geojson-conv/actions/workflows/ci.yml/badge.svg)](https://github.com/node-gis/csv-geojson-conv/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/csv-geojson-conv.svg)](https://www.npmjs.com/package/csv-geojson-conv)
-[![npm downloads](https://img.shields.io/npm/dm/csv-geojson-conv.svg)](https://www.npmjs.com/package/csv-geojson-conv)
-[![license](https://img.shields.io/npm/l/csv-geojson-conv.svg)](https://github.com/node-gis/csv-geojson-conv/blob/main/LICENSE)
+[![npm version](https://img.shields.io/npm/v/@node-gis/csv-geojson-conv.svg)](https://www.npmjs.com/package/@node-gis/csv-geojson-conv)
+[![npm downloads](https://img.shields.io/npm/dm/@node-gis/csv-geojson-conv.svg)](https://www.npmjs.com/package/@node-gis/csv-geojson-conv)
+[![license](https://img.shields.io/npm/l/@node-gis/csv-geojson-conv.svg)](https://github.com/node-gis/csv-geojson-conv/blob/main/LICENSE)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv?ref=badge_shield)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnode-gis%2Fcsv-geojson-conv?ref=badge_shield&issueType=security)
 
@@ -12,20 +12,20 @@ A tiny ESM/CJS module that converts a CSV string into a GeoJSON `FeatureCollecti
 ## Install
 
 ```sh
-npm install csv-geojson-conv
+npm install @node-gis/csv-geojson-conv
 # or
-yarn add csv-geojson-conv
+yarn add @node-gis/csv-geojson-conv
 # or
-bun add csv-geojson-conv
+bun add @node-gis/csv-geojson-conv
 ```
 
 ## Usage
 
 ```js
 // ESM
-import csvToGeojson from 'csv-geojson-conv';
+import csvToGeojson from '@node-gis/csv-geojson-conv';
 // CommonJS
-const csvToGeojson = require('csv-geojson-conv');
+const csvToGeojson = require('@node-gis/csv-geojson-conv');
 
 const csv = `Latitude,Longitude,Region,Name,Note
 37.4355672,126.9388092,서울,서울본부,
@@ -52,7 +52,7 @@ Result:
 ### Browser (fetch)
 
 ```js
-import csvToGeojson from 'csv-geojson-conv';
+import csvToGeojson from '@node-gis/csv-geojson-conv';
 
 fetch('data/points.csv')
   .then((res) => res.text())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "csv-geojson-conv",
-  "version": "1.0.0-beta.4",
+  "name": "@node-gis/csv-geojson-conv",
+  "version": "1.0.0-beta.5",
   "description": "ESM/CJS module to convert CSV string to GeoJSON in node.js or browser",
   "packageManager": "bun@1.3.9",
   "author": {
@@ -29,6 +29,9 @@
     "lib/"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
     "check": "bun run build && bun test",


### PR DESCRIPTION
## Summary
- Rename package to scoped **`@node-gis/csv-geojson-conv`**.
- Add `publishConfig.access: "public"` (scoped packages default to restricted/private).
- Update README title, npm badges, install + import examples to the scoped name.
- Bump version `1.0.0-beta.4` → `1.0.0-beta.5`.

## Why the version bump
`@node-gis/csv-geojson-conv@1.0.0-beta.4` was published then unpublished. npm **reserves** an unpublished version — it can never be republished. `beta.5` is the next usable version.

## Release (after merge)
1. Confirm `NPM_TOKEN` secret (granular/automation, 2FA-bypass).
2. Tag + push:
   ```sh
   git checkout main && git pull
   git tag v1.0.0-beta.5 && git push origin v1.0.0-beta.5
   ```
3. Release workflow publishes `@node-gis/csv-geojson-conv@1.0.0-beta.5` under the `next` dist-tag.

## Test
- `bun run build` clean
- `bun test` 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)