### PR TITLE
chore: release v1.0.0-beta.7 (TopoJSON output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7]
+
 ### Added
 
 - TopoJSON output: new named export `csvToTopoJSON(csv, options)` (with an
@@ -55,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README rewritten in English, leading with the CSV → GeoJSON value
   proposition and a no-install quick start.
 
-[Unreleased]: https://github.com/node-gis/csv-geojson-conv/compare/v1.0.0-beta.6...HEAD
+[Unreleased]: https://github.com/node-gis/csv-geojson-conv/compare/v1.0.0-beta.7...HEAD
+[1.0.0-beta.7]: https://github.com/node-gis/csv-geojson-conv/compare/v1.0.0-beta.6...v1.0.0-beta.7
 [1.0.0-beta.6]: https://github.com/node-gis/csv-geojson-conv/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/node-gis/csv-geojson-conv/releases/tag/v1.0.0-beta.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@node-gis/csv-geojson-conv",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "description": "Convert CSV to GeoJSON or TopoJSON in Node.js or the browser — ESM/CJS library plus a zero-install CLI (npx/bunx)",
   "packageManager": "bun@1.3.9",
   "author": {


### PR DESCRIPTION
Bump to **1.0.0-beta.7** to release TopoJSON output (`csvToTopoJSON` + CLI `--format`).

After merge, tag `v1.0.0-beta.7` is pushed to trigger the release workflow (publishes to the `next` dist-tag with provenance).

- 31/31 tests pass
- CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)